### PR TITLE
Update main.js to fix typo

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,2 +1,2 @@
-module.exports.ChiliConnector = require('./lib/chiliConnector.js');
+module.exports.ChiliConnector = require('./lib/chiliconnector.js');
 // module.exports.ChiliConnectorOld = require('./lib/chiliConnetorOld');


### PR DESCRIPTION
The reference to `./lib/chiliConnector.js` has a capitalized C, whereas the file that it references does not. This causes fatal errors when executing on case-sensitive file systems.